### PR TITLE
Get kernel_task(kernel_base, etc) by parsing cpu_data.

### DIFF
--- a/ktrw_kext_loader/kernel/kernel_parameters.c
+++ b/ktrw_kext_loader/kernel/kernel_parameters.c
@@ -36,8 +36,11 @@ offsets__iphone10_1__16C101() {
 	OFFSET(proc, p_list_next)               = 0;
 	OFFSET(proc, task)                      = 0x10;
 	OFFSET(proc, p_pid)                     = 0x60;
+	OFFSET(task, tasks)                     = 0x28;
 	OFFSET(task, itk_space)                 = 0x300;
 	OFFSET(task, bsd_info)                  = 0x358;
+	OFFSET(thread, task)                    = 0x370;
+	OFFSET(cpu_data, cpu_active_thread)     = 0x48;
 	STATIC_ADDRESS(kernel_base)             = 0xFFFFFFF007004000;
 }
 

--- a/ktrw_kext_loader/kernel/kernel_parameters.h
+++ b/ktrw_kext_loader/kernel/kernel_parameters.h
@@ -49,8 +49,15 @@ extern size_t OFFSET(proc, task);
 extern size_t OFFSET(proc, p_pid);
 
 // Parameters for struct task.
+extern size_t OFFSET(task, tasks);
 extern size_t OFFSET(task, itk_space);
 extern size_t OFFSET(task, bsd_info);
+
+// Parameters for struct cpu_data
+extern size_t OFFSET(cpu_data, cpu_active_thread);
+
+// Parameters for struct thread
+extern size_t OFFSET(thread, task);
 
 // The static address of the allproc variable.
 extern uint64_t STATIC_ADDRESS(allproc);


### PR DESCRIPTION
use `mach_vm_region_recurse` to find the `cpu_data` region, and parse it.

here is what the original code looks like.

```
// kern_utilities.c
kern_addr_t get_pid_task_via_iter_tasks_queue(pid_t pid, kern_addr_t task) {
  kern_addr_t task_addr = task;

  kern_addr_t KernVar(tasks);
  KernVar(tasks) = cache("kern.tasks");
  if (!KernVar(tasks)) {
    while (task_addr != 0) {
      kern_addr_t proc_addr = ReadKern64(task_addr + KERN_STRUCT_OFFSET(task, bsd_info));
      uint32_t pid_found    = ReadKern32(proc_addr + KERN_STRUCT_OFFSET(proc, p_pid));
      if (pid_found == 0) {
        KernVar(tasks) =
            ReadKern64(task_addr + KERN_STRUCT_OFFSET(task, tasks) + KERN_STRUCT_OFFSET(queue_entry, prev));
        LOG("found kern.tasks(%p)", (void *)KernVar(tasks));
        break;
      }
      task_addr = ReadKern64(task_addr + KERN_STRUCT_OFFSET(task, tasks) + KERN_STRUCT_OFFSET(queue_entry, prev));
    }
  }

  task_addr = ReadKern64(KernVar(tasks) + KERN_STRUCT_OFFSET(queue_entry, next));

  do {
    kern_addr_t proc_addr = ReadKern64(task_addr + KERN_STRUCT_OFFSET(task, bsd_info));

    uint32_t pid_found = ReadKern32(proc_addr + KERN_STRUCT_OFFSET(proc, p_pid));

    if (pid_found == pid) {
      return task_addr;
    }

    task_addr = ReadKern64(task_addr + KERN_STRUCT_OFFSET(task, tasks) + KERN_STRUCT_OFFSET(queue_entry, next));
  } while (task_addr != KernVar(tasks));

  return 0;
}

// jailbreak_kit.c
#define VM_KERN_MEMORY_CPU 9
static kern_addr_t find_cpu_data_1() {

  kern_addr_t cpu_data_kern_addr;

  kern_return_t kr;
  struct vm_region_submap_short_info_64 submap_info;
  mach_msg_type_number_t count = VM_REGION_SUBMAP_SHORT_INFO_COUNT_64;
  mach_vm_address_t addr       = 0;
  mach_vm_size_t size          = 0;
  natural_t depth              = 0;
  while (true) {
    count            = VM_REGION_SUBMAP_SHORT_INFO_COUNT_64;
    kern_return_t kr = mach_vm_region_recurse(assert_cache("tfp0"), &addr, &size, &depth,
                                              (vm_region_recurse_info_t)&submap_info, &count);
    if (kr == KERN_INVALID_ADDRESS) {
      break;
    } else {
      KERN_RETURN_ASSERT(kr);
    }

    if (0 && submap_info.is_submap) {
      ++depth;
    } else {
#if 0
      LOG("region: %p - %p, size: 0x%x, prot: %d, tag: %d, offset: %p", addr, addr + size, size, submap_info.protection,
          submap_info.user_tag, submap_info.offset);
#endif
      if (submap_info.user_tag == VM_KERN_MEMORY_CPU) {
        unsigned short cpu_number = ReadKern32(addr);
        if (cpu_number == 0x1)
          return addr;
      }
      addr += size;
    }
  }
  return 0;
}

static void handle_cpu_data_trick(kern_addr_t cpu_data_kern_addr) {
  kern_addr_t cpu_active_thread = ReadKern64(cpu_data_kern_addr + KERN_STRUCT_OFFSET(cpu_data, cpu_active_thread));
  kern_addr_t task_kern_addr    = ReadKern64(cpu_active_thread + KERN_STRUCT_OFFSET(thread, task));

  kern_addr_t KernVar(kernel_task) = get_pid_task_via_iter_tasks_queue(0, task_kern_addr);
  stash("kern.kernel_task", KernVar(kernel_task));
  LOG("found kern.kernel_task(%p)", (void *)KernVar(kernel_task));
  kern_addr_t KernVar(kernproc) = ReadKern64(KernVar(kernel_task) + KERN_STRUCT_OFFSET(task, bsd_info));
  stash("kern.kernproc", KernVar(kernproc));
  LOG("found kern.kernproc(%p)", (void *)KernVar(kernproc));
  kern_addr_t KernVar(kernel_map) = ReadKern64(KernVar(kernel_task) + KERN_STRUCT_OFFSET(task, map));
  stash("kern.kernel_map", KernVar(kernel_map));
  LOG("found kern.kernel_map(%p)", (void *)KernVar(kernel_map));
}
```